### PR TITLE
removing ui-view attribute

### DIFF
--- a/client/app/tool/tool.html
+++ b/client/app/tool/tool.html
@@ -75,7 +75,7 @@
       Tool Information
     </h2>
 
-    <div class="ui page grid" ui-view> <!-- For nested reviews child -->
+    <div class="ui page grid"> <!-- For nested reviews child -->
       <div class="sixteen wide column">
         <div class="ui equal width center aligned padded grid segmentinternally celled stackable">
           <div class="row">


### PR DESCRIPTION
Solving duplicate review bug that's crept in, by removing the `ui-view` attribute on the tool information component. 
